### PR TITLE
Assure that fundamental environment exists

### DIFF
--- a/nds/harfbuzz/PKGBUILD
+++ b/nds/harfbuzz/PKGBUILD
@@ -21,6 +21,8 @@ depends=('nds-freetype')
 groups=('nds-portlibs')
 
 build() {
+
+  source /opt/devkitpro/ndsvars.sh
   cd harfbuzz-${pkgver}
   patch -Np1 -i ${srcdir}/harfbuzz-${pkgver}.patch
 


### PR DESCRIPTION
Assuming here that `ninja` already has what it needs during packaging.